### PR TITLE
Hayden develop

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ let tlsUsers = {
     pendingPromise: null
 };
 
-let autoCacheTimeout = 10000;
+let autoCacheTimeout = 15000;
 let pageLimit = 100;
 
 let tlsTagNames = {
@@ -243,11 +243,11 @@ module.exports = {
             }
         }
         else if( ( Date.now() - cache.lastUpdated ) >= cache.refreshTime ) {
-            //console.log( cache.name + ' cache needs to be refreshed, it is ' + (Date.now() - cache.lastUpdated) + 'ms old'); 
+            console.log( cache.name + ' cache age X, it is ' + (Date.now() - cache.lastUpdated) + 'ms old !!!'); 
             return updateFunc();
         }
         else {
-            //console.log(cache.name + ' cache age is acceptable, it is ' + (Date.now() - cache.lastUpdated) + 'ms old'); 
+            console.log( cache.name + ' cache age $, it is ' + (Date.now() - cache.lastUpdated) + 'ms old'); 
             return cache.pendingPromise;
         }
     },
@@ -290,13 +290,15 @@ module.exports = {
      * 
      */
     autoCacheCheck: function(timeout){
-        setTimeout(function(){
-            //do tasks
+        let tlsAsana = this;
 
-            //call this function again
-            console.log(this);
-            console.log(this.autoCacheCheck);
-        }, timeout);
+        return new Promise(function(resolve, reject){
+            setTimeout(function(){
+                resolve(tlsAsana.checkBothCaches());
+            }, timeout);
+        }).then(() => {
+            return tlsAsana.autoCacheCheck(timeout);
+        });
     },
 
 

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = {
                 tlsUsers.data = response.data;
                 tlsUsers.lastUpdated = Date.now();
                 resolve(response);
-            });
+            }).catch( err => reject(err) );
         });
 
         return tlsUsers.pendingPromise;
@@ -140,7 +140,7 @@ module.exports = {
 
                     tlsTagNames['lastUpdated'] = Date.now();
                 }
-            });
+            }).catch( err => reject(err) );
         });
 
         return tlsTagNames.pendingPromise;
@@ -184,7 +184,7 @@ module.exports = {
 
                     tlsTasks['lastUpdated'] = Date.now();
                 }
-            });
+            }).catch( err => reject(err) );
         });
 
         return tlsTasks.pendingPromise;
@@ -223,7 +223,7 @@ module.exports = {
                     let combinedTagData = previousResponse.data.concat(response.data);
                     resolve(combinedTagData);
                 }
-            });
+            }).catch( err => reject(err) );
         });
     },
 
@@ -304,7 +304,7 @@ module.exports = {
             }, timeout);
         }).then(() => {
             return tlsAsana.autoCacheCheck(timeout);
-        });
+        }).catch( err => reject(err) );
     },
 
 
@@ -320,7 +320,7 @@ module.exports = {
             return _.filter(tlsTasks.data, function(x){
                 return _.find(x.tags, {'id': tag});
             });
-        });
+        }).catch( err => reject(err) );
     },
 
 
@@ -356,7 +356,7 @@ module.exports = {
             return _.find(tlsTasks.data, function(x){
                 return x.id == taskID;
             })
-        });
+        }).catch( err => reject(err) );
     },
 
 
@@ -371,7 +371,7 @@ module.exports = {
         
         return this.checkBothCaches().then(function(){
             return tlsAsana.getTasksByTag( tlsTagNames.captioning_unassigned );
-        });
+        }).catch( err => reject(err) );
     },
 
 
@@ -386,7 +386,7 @@ module.exports = {
         
         return this.checkBothCaches().then(function(){
             return tlsAsana.getTasksByTag( tlsTagNames['New Request'] );
-        });
+        }).catch( err => reject(err) );
     },
     
 
@@ -400,7 +400,7 @@ module.exports = {
         return new Promise( function(resolve, reject){
             client.projects.findAll({team:tlsVars.TEAM_TLSMEDIA}).then( function(projectList){
                 resolve(projectList.data);
-            });
+            }).catch( err => reject(err) );
         });
     },
 

--- a/index.js
+++ b/index.js
@@ -243,11 +243,11 @@ module.exports = {
             }
         }
         else if( ( Date.now() - cache.lastUpdated ) >= cache.refreshTime ) {
-            console.log( cache.name + ' cache age X, it is ' + (Date.now() - cache.lastUpdated) + 'ms old !!!'); 
+            //console.log( cache.name + ' cache age X, it is ' + (Date.now() - cache.lastUpdated) + 'ms old --- !!!'); 
             return updateFunc();
         }
         else {
-            console.log( cache.name + ' cache age $, it is ' + (Date.now() - cache.lastUpdated) + 'ms old'); 
+            //console.log( cache.name + ' cache age $, it is ' + (Date.now() - cache.lastUpdated) + 'ms old'); 
             return cache.pendingPromise;
         }
     },

--- a/index.js
+++ b/index.js
@@ -59,7 +59,13 @@ module.exports = {
      **/
     connect: function (requestedProjectID) {
         let tlsAsana = this;
-        projectID = requestedProjectID;
+
+        if( !(typeof requestedProjectID == "string") ){
+            throw new TypeError('Requested project ID parameter must be a string') ;
+        }
+        else {
+            projectID = requestedProjectID;
+        }
 
         return new Promise(function(resolve, reject){
             try {

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ let tlsUsers = {
     pendingPromise: null
 };
 
+let autoCacheTimeout = 10000;
 let pageLimit = 100;
 
 let tlsTagNames = {
@@ -66,6 +67,7 @@ module.exports = {
                 if (client) {
                     tlsAsana.updateTagNames();
                     tlsAsana.updateTasks();
+                    tlsAsana.autoCacheCheck(autoCacheTimeout);
                     resolve(client);
                 }
             }
@@ -283,6 +285,19 @@ module.exports = {
         return Promise.all(promiseArray);
     },
 
+
+    /**
+     * 
+     */
+    autoCacheCheck: function(timeout){
+        setTimeout(function(){
+            //do tasks
+
+            //call this function again
+            console.log(this);
+            console.log(this.autoCacheCheck);
+        }, timeout);
+    },
 
 
     /**

--- a/index.js
+++ b/index.js
@@ -440,7 +440,8 @@ module.exports = {
     /**
      * Create new task
      */
-    createTask(projectID, name, description, due_date, dataObj){
+    //createTask: function(projectID, name, description, due_date, dataObj){
+    createTask: function(name, dataObj){
         
         //1. Have to handle assignee here...have to make a function to 
         //   look at assignee data and get an id by a name or something
@@ -448,20 +449,21 @@ module.exports = {
         //2. Just have to quick test the due_date to make sure thats what the 
         //   API wants----may also have to do some JS date formatting
 
-        /*
+        console.log('data submitted to createTask func')
+        console.log(dataObj);
+
         return client.tasks.create({
                 'name': name,
-                'description': description,
-                //'assignee': {'id': '170705266868499'},
-                //'due_date': due_date //still have to test
+                'description': 'description',
+                'assignee': {'id': '170705266868499'},
                 'workspace': 36641419235321,
-                'projects': [projectID],//166216691534199
+                'projects': projectID,
                 'external': {
                     'data': JSON.stringify(dataObj)
                 }
             }
         );
-        */
+        
     }
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,12 @@
 "use strict";
+let _ = require('lodash');
 var assert = require('assert');
 var tlsAsana = require('../index.js');
 var tlsConsts = require('../tlsConstants.js');
+
 let client = undefined;
 let tlsTasks;
+
 /**
  * Test cache so that we can make sure a refresh function is being called 
  * for our caches without having to alter their production refresh times
@@ -89,20 +92,32 @@ describe('Querying our local caches', function(){
     });
     
     it('Should get all of the local tasks that have a certain tag', function(){
-        return tlsAsana.getTasksByTag(167304830178312).then(taskArray => {
-            assert(taskArray.length > 0, 'Failed to get local tasks with a certain tag');
+        let tagID = 167304830178312;
+        
+        return tlsAsana.getTasksByTag(tagID).then(taskArray => {
+            assert.notDeepEqual(_.filter(taskArray[0].tags, x => {
+                return x.id === tagID;
+            }), [], 'Failed to return a task with the correct tag');
         })   
     });
     
-    it('Should get all of the local tasks that have an unassigned tag', function(){
+    it('Should get all of the local tasks that have an unassigned tag', function(){     
+        let unassignedTagID = 167304830178312;
+        
         return tlsAsana.getUnassignedTasks().then(taskArray => {
-            assert(taskArray.length > 0, 'Failed to get local tasks with the unassigned tag');
+            assert.notDeepEqual(_.filter(taskArray[0].tags, x => {
+                return x.id === unassignedTagID;
+            }), [], 'Failed to return a task with an unassigned tag');
         });
     });
 
     it('Should get all of the local tasks that have a new task tag', function(){
+        let newTagID = 44184307053951;
+        
         return tlsAsana.getNewTasks().then(taskArray => {
-            assert(taskArray.length > 0, 'Failed to get local tasks with the new task tag');
+            assert.notDeepEqual(_.filter(taskArray[0].tags, x => {
+                return x.id === newTagID;
+            }), [], 'Failed to return a task with a new task tag');
         });
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -47,29 +47,28 @@ describe('Making sure caches update', function(){
     
     it('Should update the tag cache', function(){
         this.timeout(8000);
-        return tlsAsana.updateTagNames(10).then(function(response){
-            assert.equal(response.Accepted,167304830178303,'Failed to update the tag cache');
-        })
+        return tlsAsana.updateTagNames(10).then( response => assert.equal(response.Accepted,167304830178303,'Failed to update the tag cache') );
     });
 
     it('Should update the task cache', function(){
         this.timeout(8000);
-        return tlsAsana.updateTasks().then(function(response){
+        return tlsAsana.updateTasks().then(response => {
             tlsTasks = response;
-            assert.equal(response.data[0].id, 180230098413779, 'Failed to update task cache');
-        })
+            var testTask = _.filter(tlsTasks.data, ['created_at', "2016-08-26T20:13:13.727Z"]);
+            assert.equal(testTask[0].id, 172981416524848, 'Failed to update task cache');
+        });
     });
     
     it('Should get the tags associated with a task when the tasks are cached', function(){
         if(!tlsTasks){
             throw "Error, cannot check the tags associated with a task if the task cache did not update";
         } 
-        assert.equal(tlsTasks.data[4].tags[0].name,"New Request",'Failed to get tags associated with tasks');
+        var testTask = _.filter(tlsTasks.data, ['created_at', "2016-08-26T20:13:13.727Z"]);
+        assert.equal(testTask[0].tags[1].name,"testing",'Failed to get tags associated with tasks');
     });
 
     it('Should update a local cache if it is older than its set refresh time', function(){
         this.timeout(8000);
-
         assert(tlsAsana.checkLastCacheUpdate(testCache, testCache.testRefresh), 'Failed to update local cache');
     });
 
@@ -80,15 +79,11 @@ describe('Making sure caches update', function(){
 describe('Querying our local caches', function(){
     
     it('Should get information about a specific task from the local tag cache', function(){
-        return tlsAsana.getTaskInfoByID(169176168459508).then(taskInfo => {
-            assert.equal(taskInfo.created_at, '2016-08-17T21:06:24.132Z', 'getting specific task info failed'); 
-        })
+        return tlsAsana.getTaskInfoByID(169176168459508).then( taskInfo => assert.equal(taskInfo.created_at, '2016-08-17T21:06:24.132Z', 'getting specific task info failed') ); 
     });
 
     it('Should get a cached tag id from the local tag cache', function(){
-        return tlsAsana.getTagIDByName('captioning_unassigned').then(tagID => {
-            assert.equal(tagID, 167304830178312, 'Failed to get cached tag id');
-        });
+        return tlsAsana.getTagIDByName('captioning_unassigned').then( tagID => assert.equal(tagID, 167304830178312, 'Failed to get cached tag id') );
     });
     
     it('Should get all of the local tasks that have a certain tag', function(){
@@ -98,7 +93,7 @@ describe('Querying our local caches', function(){
             assert.notDeepEqual(_.filter(taskArray[0].tags, x => {
                 return x.id === tagID;
             }), [], 'Failed to return a task with the correct tag');
-        })   
+        });
     });
     
     it('Should get all of the local tasks that have an unassigned tag', function(){     
@@ -130,9 +125,7 @@ describe('Querying Asana', function(){
     it('Should get all of the projects from Asana', function(){
         this.timeout(8000);
 
-        return tlsAsana.getAllProjects().then(projects => { 
-            assert.ok( projects.length > 0 ); 
-        });
+        return tlsAsana.getAllProjects().then( projects => assert.ok( projects.length > 0 ) ); 
     });
     
 });
@@ -143,30 +136,20 @@ describe('Working with tags in Asana', function(){
     it("Should change a task's tag from captioning_unassigned to captioning_accepted", function(){
         this.timeout(8000);
         
+        //Test looks at the tag in the first position of the tag array for this 
+        //task,so the test may be broken if other tags are added to this task
         return tlsAsana.switchTag('166304358745259', 'captioning_unassigned', 'captioning_accepted').then(tag => {
-                return client.tasks.findById('166304358745259').then(taskInfo => {  
-                    //Test looks at the tag in the first position of the tag array for this 
-                    //task,so the test may be broken if other tags are added to this task
-                    
-                    // console.log('Task tag switched to:');
-                    // console.log(taskInfo.tags[0]);
-                    assert.strictEqual(taskInfo.tags[0].name, 'captioning_accepted', 'tag change failed');
-                });
+            return client.tasks.findById('166304358745259').then( taskInfo => assert.strictEqual(taskInfo.tags[0].name, 'captioning_accepted', 'tag change failed') );
         });
     });
 
     it("Should change a task's tag from captioning_accepted to captioning_unassigned", function(){
         this.timeout(8000);
         
+        //Test looks at the tag in the first position of the tag array for this 
+        //task,so the test may be broken if other tags are added to this task
         return tlsAsana.switchTag('166304358745259', 'captioning_accepted', 'captioning_unassigned').then(tag => {
-                return client.tasks.findById('166304358745259').then(taskInfo => {  
-                    //Test looks at the tag in the first position of the tag array for this 
-                    //task,so the test may be broken if other tags are added to this task
-                    
-                    // console.log('Task tag switched to:');
-                    // console.log(taskInfo.tags[0]);
-                    assert.strictEqual(taskInfo.tags[0].name, 'captioning_unassigned', 'tag change failed');
-                });
+            return client.tasks.findById('166304358745259').then( taskInfo => assert.strictEqual(taskInfo.tags[0].name, 'captioning_unassigned', 'tag change failed') );
         });
     });
 
@@ -175,9 +158,8 @@ describe('Working with tags in Asana', function(){
     it('Should look up an undefined tag and receive a tag error', function(){
         this.timeout(8000);
         
-        return tlsAsana.getTagIDByName('blahblahblah').then( response => {
-            assert.ok(false, 'Undefined tag did not throw an error');
-        }).catch(err => {
+        return tlsAsana.getTagIDByName('blahblahblah').then( response => assert.ok(false, 'Undefined tag did not throw an error') )
+        .catch(err => {
             if ( (err instanceof Error) && /Error, no tag exists in the cache with that name/.test(err) ) {
                 assert.ok(true);
             }

--- a/test/test.js
+++ b/test/test.js
@@ -24,11 +24,16 @@ let testCache = {
 
 describe('Connecting to Asana', function(){
 
+   //need to include some use of tlsAsana (getAllProjects in this case) 
+   //to evaluate connection--if auth fails an error is thrown before the assert message
    it('Should setup the connection', function(){
         this.timeout(8000);
         return tlsAsana.connect('166216691534199').then(function(response){
             client = response;
-            assert(response,'Connection failed');
+                
+            return tlsAsana.getAllProjects().then( projectArray => {
+                assert(Array.isArray( projectArray ), 'Connection authorized, but cannot get projects');
+            });
         });
    });
 

--- a/test/testHayden.js
+++ b/test/testHayden.js
@@ -17,7 +17,6 @@ describe('Connecting to Asana', function(){
         this.timeout(8000);
         return tlsAsana.connect('166216691534199').then(function(response){
             client = response;
-            //console.log(client);
             assert(response,'Connection failed');
         });
    });
@@ -25,35 +24,20 @@ describe('Connecting to Asana', function(){
 //// CONNECTION -----------------------------------
 
 
-describe('Working with tags in Asana', function(){
-
-    it('changes a tag from captioning_unassigned to captioning_accepted', function(){
-        this.timeout(8000);
-        
-        return tlsAsana.switchTag('166304358745259', 'captioning_unassigned', 'captioning_accepted').then(tag => {
-                return client.tasks.findById('166304358745259').then(taskInfo => {  
-                    //Test looks at the tag in the first position of the tag array for this 
-                    //task,so the test may be broken if other tags are added to this task
-                    console.log('Task tag switched to:');
-                    console.log(taskInfo.tags[0]);
-                    assert.strictEqual(taskInfo.tags[0].name, 'captioning_accepted', 'tag change failed');
-                });
-        });
-    });
-
-    it('changes a tag from captioning_accepted to captioning_unassigned', function(){
-        this.timeout(8000);
-        
-        return tlsAsana.switchTag('166304358745259', 'captioning_accepted', 'captioning_unassigned').then(tag => {
-                return client.tasks.findById('166304358745259').then(taskInfo => {  
-                    //Test looks at the tag in the first position of the tag array for this 
-                    //task,so the test may be broken if other tags are added to this task
-                    console.log('Task tag switched to:');
-                    console.log(taskInfo.tags[0]);
-                    assert.strictEqual(taskInfo.tags[0].name, 'captioning_unassigned', 'tag change failed');
-                });
+describe('Autocheck', function(){
+    it('Should autocheck both caches', function(){
+        this.timeout(200000);
+        // return tlsAsana.autoCacheCheck(1000).then(response => {
+        //     console.log(response);
+        //     assert(response, 'error');
+        // })
+        return tlsAsana.autoCacheCheck(60000).then( response => {
+            console.log(response);
+            assert(response, 'no response');
+            //assert(response.data[0].name, "Chris Hodge", 'shit failed');
         });
     });
 
 });
+
 


### PR DESCRIPTION
- Adds timer to check and update caches automatically instead of waiting for a user request in all cases
- 'createTask' function is usable but still needs some fine-tuning
- Improved error catching and rejection of promises and improved accuracy and longevity of some tests: most notably a certain task is filtered by its creation date and then its details are tested, instead of testing a task based on its position in the task array (which would change and break the test whenever a new task was added)
